### PR TITLE
Fix error when a boost repo tag isn't a valid semver

### DIFF
--- a/lib/boostDownloader.js
+++ b/lib/boostDownloader.js
@@ -113,11 +113,16 @@ BoostDownloader.prototype._download = function () {
                         var parts = line.split(/\s+/);
                         if (parts.length === 2) {
                             var relVersion = parts[1].substr("refs/tags/boost-".length);
-                            self.log.verbose("BOOST", "Comparing version: " + relVersion);
-                            if (semver.satisfies(relVersion, self.version)) {
-                                self.log.verbose("BOOST", "Version OK.");
-                                downloadVersion = relVersion;
-                                return false;
+
+                            // Fix error when a tag is not a valid semver, by validating first
+                            var sv = semver.valid(relVersion);
+                            if (sv) {
+                                self.log.verbose("BOOST", "Comparing version: " + relVersion);
+                                if (semver.satisfies(sv, self.version)) {
+                                    self.log.verbose("BOOST", "Version OK.");
+                                    downloadVersion = relVersion;
+                                    return false;
+                                }
                             }
                         }
                     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boost-lib",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Boost dependency manager for CMake.js based native modules",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Fixes an error that occurs due to one of the tags on the boost repo not being a valid semver. And bumping the patch version accordingly.