### PR TITLE
Add --ignore-site-config to fix modular boost build

### DIFF
--- a/cmake/GetBoostLibB2Args.cmake
+++ b/cmake/GetBoostLibB2Args.cmake
@@ -18,7 +18,8 @@ function(get_boots_lib_b2_args)
                stage
                --stagedir=${stage_dir}
                -d+2
-               --hash)
+               --hash
+               --ignore-site-config)
                
     message(STATUS "Generating b2 args.")
     


### PR DESCRIPTION
On Gentoo Linux, the OOTB Boost configuration file has some invalid
options which breaks b2 execution. The official (prescribed) way is to
ignore the site configuration file.

Source http://lists.boost.org/boost-users/2014/04/81846.php

Fix #3
Fix cmake-js/cmake-js#58